### PR TITLE
Update Geany to 1.36

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.geany.Geany.appdata.xml
+++ b/org.geany.Geany.appdata.xml
@@ -40,6 +40,7 @@ as possible from a specific Desktop Environment like KDE or GNOME.</p>
   <update_contact>https://github.com/geany/geany</update_contact>
   <translation type="gettext">geany</translation>
   <releases>
+    <release date="2019-09-28" version="1.36"/>
     <release date="2019-04-28" version="1.35"/>
   </releases>
   <content_rating type="oars-1.1"/>

--- a/org.geany.Geany.appdata.xml
+++ b/org.geany.Geany.appdata.xml
@@ -28,13 +28,13 @@ as possible from a specific Desktop Environment like KDE or GNOME.</p>
   </description>
   <screenshots>
     <screenshot type="default">
-      <image height="808" width="942">http://www.geany.org/uploads/Gallery/geany_main.png</image>
+      <image width="1366" height="741">http://www.geany.org/uploads/Gallery/geany_main.png</image>
     </screenshot>
     <screenshot>
-      <image height="808" width="942">http://www.geany.org/uploads/Gallery/geany_build.png</image>
+      <image width="1366" height="741">http://www.geany.org/uploads/Gallery/geany_build.png</image>
     </screenshot>
     <screenshot>
-      <image height="808" width="942">http://www.geany.org/uploads/Gallery/geany_vte.png</image>
+      <image width="1366" height="741">http://www.geany.org/uploads/Gallery/geany_vte.png</image>
     </screenshot>
   </screenshots>
   <update_contact>https://github.com/geany/geany</update_contact>

--- a/org.geany.Geany.appdata.xml
+++ b/org.geany.Geany.appdata.xml
@@ -28,13 +28,13 @@ as possible from a specific Desktop Environment like KDE or GNOME.</p>
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>http://www.geany.org/uploads/Gallery/geany_main.png</image>
+      <image>https://www.geany.org/uploads/Gallery/geany_main.png</image>
     </screenshot>
     <screenshot>
-      <image>http://www.geany.org/uploads/Gallery/geany_build.png</image>
+      <image>https://www.geany.org/uploads/Gallery/geany_build.png</image>
     </screenshot>
     <screenshot>
-      <image>http://www.geany.org/uploads/Gallery/geany_vte.png</image>
+      <image>https://www.geany.org/uploads/Gallery/geany_vte.png</image>
     </screenshot>
   </screenshots>
   <update_contact>https://github.com/geany/geany</update_contact>

--- a/org.geany.Geany.appdata.xml
+++ b/org.geany.Geany.appdata.xml
@@ -28,13 +28,13 @@ as possible from a specific Desktop Environment like KDE or GNOME.</p>
   </description>
   <screenshots>
     <screenshot type="default">
-      <image width="1366" height="741">http://www.geany.org/uploads/Gallery/geany_main.png</image>
+      <image>http://www.geany.org/uploads/Gallery/geany_main.png</image>
     </screenshot>
     <screenshot>
-      <image width="1366" height="741">http://www.geany.org/uploads/Gallery/geany_build.png</image>
+      <image>http://www.geany.org/uploads/Gallery/geany_build.png</image>
     </screenshot>
     <screenshot>
-      <image width="1366" height="741">http://www.geany.org/uploads/Gallery/geany_vte.png</image>
+      <image>http://www.geany.org/uploads/Gallery/geany_vte.png</image>
     </screenshot>
   </screenshots>
   <update_contact>https://github.com/geany/geany</update_contact>

--- a/org.geany.Geany.json
+++ b/org.geany.Geany.json
@@ -24,7 +24,6 @@
         {
           "type": "archive",
           "url": "https://download.geany.org/geany-1.36.tar.bz2",
-          "sha256": "9184dd3dd40b7b84fca70083284bb9dbf2ee8022bf2be066bdc36592d909d53e",
           "sha512": "15005772b64e8321d7fa8552363df425eb25e9d7b0760c561c8fb3f34d7acae2bf25da8e04fda38a2a1b64cc31ff613b7ff2786d432ff014050c138c7473c810"
         },
         {

--- a/org.geany.Geany.json
+++ b/org.geany.Geany.json
@@ -14,6 +14,7 @@
      "--filesystem=host"
   ],
   "modules": [
+    "shared-modules/intltool/intltool-0.51.json",
     {
       "name": "geany",
       "config-opts": [

--- a/org.geany.Geany.json
+++ b/org.geany.Geany.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.geany.Geany",
   "runtime": "org.gnome.Sdk",
-  "runtime-version": "3.30",
+  "runtime-version": "3.34",
   "branch": "stable",
   "sdk": "org.gnome.Sdk",
   "command": "geany",

--- a/org.geany.Geany.json
+++ b/org.geany.Geany.json
@@ -23,8 +23,9 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.geany.org/geany-1.35.tar.gz",
-          "sha256": "7a1896488e65058232ee0d5c3464d8a4ace7683ac812911740c688355d08a3af"
+          "url": "https://download.geany.org/geany-1.36.tar.bz2",
+          "sha256": "9184dd3dd40b7b84fca70083284bb9dbf2ee8022bf2be066bdc36592d909d53e",
+          "sha512": "15005772b64e8321d7fa8552363df425eb25e9d7b0760c561c8fb3f34d7acae2bf25da8e04fda38a2a1b64cc31ff613b7ff2786d432ff014050c138c7473c810"
         },
         {
           "type": "file",


### PR DESCRIPTION
- Bump Geany to 1.36
- Bump org.gnome.Sdk dependency to 3.34
- Added shared-modules repo as submodule to provide intltool required for building Geany.

Fixes #7 
