### PR TITLE
Add geany-plugins to build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.geany.Geany.appdata.xml
+++ b/org.geany.Geany.appdata.xml
@@ -40,6 +40,7 @@ as possible from a specific Desktop Environment like KDE or GNOME.</p>
   <update_contact>https://github.com/geany/geany</update_contact>
   <translation type="gettext">geany</translation>
   <releases>
+    <release date="2019-09-28" version="1.36"/>
     <release date="2019-04-28" version="1.35"/>
   </releases>
   <content_rating type="oars-1.1"/>

--- a/org.geany.Geany.appdata.xml
+++ b/org.geany.Geany.appdata.xml
@@ -28,13 +28,13 @@ as possible from a specific Desktop Environment like KDE or GNOME.</p>
   </description>
   <screenshots>
     <screenshot type="default">
-      <image height="808" width="942">http://www.geany.org/uploads/Gallery/geany_main.png</image>
+      <image width="1366" height="741">http://www.geany.org/uploads/Gallery/geany_main.png</image>
     </screenshot>
     <screenshot>
-      <image height="808" width="942">http://www.geany.org/uploads/Gallery/geany_build.png</image>
+      <image width="1366" height="741">http://www.geany.org/uploads/Gallery/geany_build.png</image>
     </screenshot>
     <screenshot>
-      <image height="808" width="942">http://www.geany.org/uploads/Gallery/geany_vte.png</image>
+      <image width="1366" height="741">http://www.geany.org/uploads/Gallery/geany_vte.png</image>
     </screenshot>
   </screenshots>
   <update_contact>https://github.com/geany/geany</update_contact>

--- a/org.geany.Geany.json
+++ b/org.geany.Geany.json
@@ -14,6 +14,7 @@
      "--filesystem=host"
   ],
   "modules": [
+    "shared-modules/intltool/intltool-0.51.json",
     {
       "name": "geany",
       "config-opts": [

--- a/org.geany.Geany.json
+++ b/org.geany.Geany.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.geany.Geany",
   "runtime": "org.gnome.Sdk",
-  "runtime-version": "3.30",
+  "runtime-version": "3.34",
   "branch": "stable",
   "sdk": "org.gnome.Sdk",
   "command": "geany",

--- a/org.geany.Geany.json
+++ b/org.geany.Geany.json
@@ -23,8 +23,9 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.geany.org/geany-1.35.tar.gz",
-          "sha256": "7a1896488e65058232ee0d5c3464d8a4ace7683ac812911740c688355d08a3af"
+          "url": "https://download.geany.org/geany-1.36.tar.bz2",
+          "sha256": "9184dd3dd40b7b84fca70083284bb9dbf2ee8022bf2be066bdc36592d909d53e",
+          "sha512": "15005772b64e8321d7fa8552363df425eb25e9d7b0760c561c8fb3f34d7acae2bf25da8e04fda38a2a1b64cc31ff613b7ff2786d432ff014050c138c7473c810"
         },
         {
           "type": "file",

--- a/org.geany.Geany.json
+++ b/org.geany.Geany.json
@@ -35,6 +35,70 @@
       "post-install": [
         "install -Dm644 -t /app/share/metainfo org.geany.Geany.appdata.xml"
       ]
+    },
+    {
+      "name" : "libgit2",
+      "buildsystem" : "cmake",
+      "config-opts" : [
+        "-DBUILD_SHARED_LIBS:BOOL=ON",
+        "-DTHREADSAFE=ON"
+      ],
+      "sources" : [
+        {
+          "type" : "git",
+          "url" : "https://github.com/libgit2/libgit2.git",
+          "branch" : "maint/v0.28"
+        }
+      ]
+    },
+    {
+      "name" : "ctpl",
+      "sources" : [
+        {
+          "type": "archive",
+          "url": "http://download.tuxfamily.org/ctpl/releases/ctpl-0.3.4.tar.gz",
+          "sha256": "3a95fdd03437ed3ae222339cb0de2d2c1240d627faa6c77bf46f1a9b761729fb"
+        }
+      ]
+    },
+    {
+      "name" : "libmarkdown",
+      "no-parallel-make" : true,
+      "config-opts": [
+        "--shared",
+        "--pkg-config",
+        "--debian-glitch"
+      ],
+      "sources" : [
+        {
+          "type" : "git",
+          "url" : "https://github.com/Orc/discount.git",
+          "branch" : "v2.2.6"
+        },
+        {
+          "type" : "shell",
+          "commands" : [
+            "mv configure.sh configure"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "geany-plugins",
+      "config-opts": [
+        "--disable-cppcheck",
+        "--disable-extra-c-warnings",
+        "--disable-peg-markdown"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://plugins.geany.org/geany-plugins/geany-plugins-1.36.tar.gz",
+          "sha1": "99a6117645a665cefe6f6861f2a2feb0137d3e75",
+          "sha256": "9f79847c2dd979dbd392819090d6cbf170a6d4fee1888f98e27c65dc2d870bbe",
+          "sha512": "b3e58b42432d17c27289fa20d10b833a2d7f5d8c72b51abe5b1ebdabcb952b18e0984b15ef6ac9753102d839f3174f28798269e1e94bf032bdaa189e98d72b2d"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Based on #8 

Adds building geany-plugins and its dependencies as separate steps after the main Geany application has been built and installed.

The build configurations for the plugins package and the dependencies are inspired by the build scripts for the corresponding packages in Fedora, Gentoo and Debian.

Briefly tested locally.

Fixes #1 