### PR TITLE
Change runtime and SDK to org.freedesktop

### DIFF
--- a/org.geany.Geany.json
+++ b/org.geany.Geany.json
@@ -1,9 +1,9 @@
 {
   "app-id": "org.geany.Geany",
-  "runtime": "org.gnome.Sdk",
-  "runtime-version": "41",
+  "runtime": "org.freedesktop.Sdk",
+  "runtime-version": "21.08",
   "branch": "stable",
-  "sdk": "org.gnome.Sdk",
+  "sdk": "org.freedesktop.Sdk",
   "command": "geany",
   "rename-icon": "geany",
   "copy-icon": true,


### PR DESCRIPTION
Geany's manifest currently targets the GNOME platform unnecessarily, and contrary to its stated goals in its description in the appdata. It is not a GNOME app, it is a DE-agnostic GTK app, so FreeDesktop is the more appropriate platform to use. Switching the runtime and SDK does not affect whether it builds or runs in any way at all.