### PR TITLE
Remove --socket=x11 finish arg.

### DIFF
--- a/org.geany.Geany.yml
+++ b/org.geany.Geany.yml
@@ -10,7 +10,6 @@ rename-desktop-file: geany.desktop
 
 finish-args:
   - --share=ipc
-  - --socket=x11
   - --socket=fallback-x11
   - --socket=wayland
   - --share=network


### PR DESCRIPTION
Both `--socket=x11` and `--socket=fallback-x11` should not be present. This is causing a build failure at present. In fact, I can't even merge this fix directly.

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: Required status check "builds/x86_64" is expected. Changes must be made through a pull request.
```

So this is the pull request that it wants.