### PR TITLE
Add version constraint to VTE to stay on GTK3-based versions.

### DIFF
--- a/org.geany.Geany.yml
+++ b/org.geany.Geany.yml
@@ -32,6 +32,8 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
+          versions:
+            <: '0.73'
   - name: geany
     config-opts:
       - --disable-api-docs


### PR DESCRIPTION
The version constraint is for the external data checker, and should prevent Flathub Bot from creating pull requests to update VTE to versions that require GTK4.