### PR TITLE
Various changes, October 2023

### DIFF
--- a/geany-plugins.yml
+++ b/geany-plugins.yml
@@ -3,8 +3,7 @@
 
 name: geany-plugins
 config-opts:
-  - --enable-webhelper
-  - --enable-markdown
+  - --enable-all-plugins
 sources:
   - type: archive
     url: https://plugins.geany.org/geany-plugins/geany-plugins-2.0.tar.bz2

--- a/geany-plugins.yml
+++ b/geany-plugins.yml
@@ -14,7 +14,7 @@ sources:
       url: https://www.geany.org/download/releases
       pattern: (https://plugins.geany.org/geany-plugins/geany-plugins-([\d\.]+).tar.bz2)
 modules:
-  - shared-modules/lua5.4/lua-5.4.json
+  - shared-modules/lua5.1/lua-5.1.5.json
   - shared-modules/libsoup/libsoup-2.4.json
   - name: libgit2
     buildsystem: cmake-ninja

--- a/org.geany.Geany.yml
+++ b/org.geany.Geany.yml
@@ -47,9 +47,6 @@ modules:
           pattern: (https://download.geany.org/geany-([\d\.]+).tar.bz2)
       - type: file
         path: org.geany.Geany.appdata.xml
-      - type: shell
-        commands:
-          - sed -i 's/firefox/xdg-open/' src/keyfile.c
     post-install:
       - install -Dm644 -t /app/share/metainfo org.geany.Geany.appdata.xml
 

--- a/webkitgtk.yml
+++ b/webkitgtk.yml
@@ -4,7 +4,7 @@
 # own yml file. I then added many extra parts from all over the Flathub org.
 # Anyone who needs to include webkitgtk, *please* feel free to use this.
 
-name: webkitgtk
+name: webkit2gtk-4.0
 buildsystem: cmake-ninja
 config-opts:
   - -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -17,7 +17,7 @@ config-opts:
   - -DENABLE_SPELLCHECK=OFF
   - -DENABLE_DOCUMENTATION=OFF
   - -DENABLE_MINIBROWSER=OFF
-  - -DENABLE_BUBBLEWRAP_SANDBOX=OFF # Unused inside of flatpak
+  - -DENABLE_BUBBLEWRAP_SANDBOX=OFF  # Unused inside of flatpak
 sources:
   - type: archive
     url: https://webkitgtk.org/releases/webkitgtk-2.42.1.tar.xz
@@ -34,8 +34,6 @@ sources:
       - sed -i 's@${AVIF_INCLUDE_DIR}/avif.h@${AVIF_INCLUDE_DIR}/avif/avif.h@'
         Source/cmake/FindAVIF.cmake
 modules:
-
-  # The rest of WebkitGTK's deps.
   - name: unifdef
     no-autogen: true
     make-install-args:

--- a/webkitgtk.yml
+++ b/webkitgtk.yml
@@ -68,8 +68,6 @@ modules:
           timestamp-query: .published_at
           version-query: $tag
           url-query: '"https://github.com/google/highway/archive/\($tag)/highway-\($version).tar.gz"'
-    cleanup:
-      - '*'
   - name: libavif
     buildsystem: cmake-ninja
     builddir: true
@@ -87,8 +85,6 @@ modules:
           timestamp-query: .published_at
           version-query: $tag | sub("^[vV]"; "")
           url-query: '"https://github.com/AOMediaCodec/libavif/archive/\($tag)/libavif-\($version).tar.gz"'
-    cleanup:
-      - '*'
   - name: libjxl
     buildsystem: cmake-ninja
     builddir: true
@@ -116,8 +112,6 @@ modules:
           timestamp-query: .published_at
           version-query: $tag | sub("^[vV]"; "")
           url-query: '"https://github.com/libjxl/libjxl/archive/\($tag)/libjxl-\($version).tar.gz"'
-    cleanup:
-      - '*'
   - name: libwpe
     buildsystem: meson
     builddir: true

--- a/webkitgtk.yml
+++ b/webkitgtk.yml
@@ -74,6 +74,7 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DAVIF_CODEC_DAV1D=ON
+      - -DBUILD_SHARED_LIBS=ON
     sources:
       - type: archive
         url: https://github.com/AOMediaCodec/libavif/archive/v1.0.1/libavif-1.0.1.tar.gz
@@ -101,6 +102,12 @@ modules:
       - -DJPEGXL_ENABLE_SJPEG=OFF
       - -DJPEGXL_ENABLE_OPENEXR=OFF
       - -DJPEGXL_ENABLE_SKCMS=OFF
+      - -DJPEGXL_FORCE_SYSTEM_BROTLI=ON
+      - -DJPEGXL_FORCE_SYSTEM_LCMS2=ON
+      - -DJPEGXL_FORCE_SYSTEM_HWY=ON
+    post-install:
+      # It doesn't respect disabling static libraries...
+      - rm $FLATPAK_DEST/lib/*.a
     sources:
       - type: archive
         url: https://github.com/libjxl/libjxl/archive/v0.8.2/libjxl-0.8.2.tar.gz

--- a/webkitgtk.yml
+++ b/webkitgtk.yml
@@ -11,7 +11,6 @@ config-opts:
   - -DPORT=GTK
   - -DUSE_SOUP2=ON  # This makes it build webkit2gtk-4.0 instead of 4.1.
   - -DUSE_LIBSECRET=OFF
-  - -DUSE_WOFF2=OFF
   - -DENABLE_GAMEPAD=OFF
   - -DENABLE_INTROSPECTION=OFF
   - -DENABLE_SPELLCHECK=OFF
@@ -68,6 +67,17 @@ modules:
           timestamp-query: .published_at
           version-query: $tag
           url-query: '"https://github.com/google/highway/archive/\($tag)/highway-\($version).tar.gz"'
+  - name: woff2
+    buildsystem: cmake-ninja
+    builddir: true
+    sources:
+      - type: archive
+        url: https://github.com/google/woff2/archive/v1.0.2.tar.gz
+        sha256: add272bb09e6384a4833ffca4896350fdb16e0ca22df68c0384773c67a175594
+        x-checker-data:
+          type: anitya
+          project-id: 17587
+          url-template: https://github.com/google/woff2/archive/v$version.tar.gz
   - name: libavif
     buildsystem: cmake-ninja
     builddir: true


### PR DESCRIPTION
- Remove sed substitution in main manifest.
    - This was to change the default browser to xdg-open so it would actually work, but now Geany uses the system handler by default, so it's no longer necessary.
- Switch Lua to 5.1.
    - GeanyLua is not actually compatible with Lua 5.4 or 5.3; oops!
- Enable all plugins in Geany-Plugins.
    - This will make it much easier to catch build problems.
- webkitgtk.yml minor changes
    - Changing the module's name to webkit2gtk-4.0 in case we attempt a migration to libsoup3 and webkit2gtk-4.1; I *think* this will let build systems keep the old build around in case it doesn't work out.
    - Style changes for the comments. Space one, axe another.
- Remove cleanups on highway, libavif, and libjxl
    - Markdown and Webhelper can't actually load if they get removed. However, libjxl seems to *hugely* bloat up the package size, and needs to be overhauled to, uh, not do that.
- Change libjxl build options.
    - For some reason, libjxl inflates the package by about 200 MB with the build options as they were before. It looks like the combination of using various system libraries and deleting static libs that are unconditionally built mitigates this.
    - Also ask libavif to build shared libs. May be redundant.
- Add woff2 to webkitgtk.
    - The ability to use web fonts could be helfpul for web dev inside of Geany, and it doesn't inflate the package by much.