### PR TITLE
Draft: Use the tree from geany/geany#3861 to test portal support.

### DIFF
--- a/org.geany.Geany.yml
+++ b/org.geany.Geany.yml
@@ -37,14 +37,11 @@ modules:
   - name: geany
     config-opts:
       - --disable-api-docs
+      - --disable-html-docs
     sources:
-      - type: archive
-        url: https://download.geany.org/geany-2.0.tar.bz2
-        sha256: 565b4cd2f0311c1e3a167ec71c4a32dba642e0fe554ae5bb6b8177b7a74ccc92
-        x-checker-data:
-          type: html
-          url: https://www.geany.org/download/releases
-          pattern: (https://download.geany.org/geany-([\d\.]+).tar.bz2)
+      - type: git
+        url: https://github.com/techee/geany.git
+        commit: 4b1be9a5776d1ca125a2b70177b618acee9b9db5
       - type: file
         path: org.geany.Geany.appdata.xml
     post-install:


### PR DESCRIPTION
Note to self / other maintainers: don't merge this. Portal support in the Flathub package should either be a patch against stable, or a feature of a stable release. In addition, we should likely use build options to default the configuration option to true for the Flathub build.

This isn't enough to be able to drop `--filesystem=host`, but the experience will be much nicer across different environments. The option that controls use of "native file choosers" is under Preferences -> General -> Miscellaneous.

This uses the tree of geany/geany#3861 in order to address geany/geany#3458.

Please feel free to install the build generated by Flathub in order to test this functionality. Hopefully I can find a way to move it somewhere less transient before it gets auto-deleted by Flathub.