### PR TITLE
Updates 2024-11

### DIFF
--- a/geany-plugins.yml
+++ b/geany-plugins.yml
@@ -27,8 +27,8 @@ modules:
       - -DBUILD_CLI=OFF
     sources:
       - type: archive
-        url: https://github.com/libgit2/libgit2/archive/refs/tags/v1.8.1.tar.gz
-        sha256: 8c1eaf0cf07cba0e9021920bfba9502140220786ed5d8a8ec6c7ad9174522f8e
+        url: https://github.com/libgit2/libgit2/archive/refs/tags/v1.8.4.tar.gz
+        sha256: 49d0fc50ab931816f6bfc1ac68f8d74b760450eebdb5374e803ee36550f26774
         x-checker-data:
           type: anitya
           project-id: 1627

--- a/geany-plugins.yml
+++ b/geany-plugins.yml
@@ -36,12 +36,8 @@ modules:
   - name: ctpl
     sources:
       - type: archive
-        url: http://download.tuxfamily.org/ctpl/releases/ctpl-0.3.3.tar.gz
-        sha256: 7da73e7d8f10d222f5685b8eb80541d7e4d342aa74673039692fa5c4e8b120a7
-      # The included config.guess fails on aarch64.
-      - type: shell
-        commands:
-          - cp -p /usr/share/automake-*/config.{sub,guess} build/aux/
+        url: http://download.tuxfamily.org/ctpl/releases/ctpl-0.3.5.tar.gz
+        sha256: 21108fc7567ed216deea4591adbfece8e88b1f4bb1ca77c37400920644d756be
   - name: enchant
     cleanup:
       - /bin

--- a/org.geany.Geany.yml
+++ b/org.geany.Geany.yml
@@ -1,6 +1,6 @@
 app-id: org.geany.Geany
 runtime: org.freedesktop.Sdk
-runtime-version: '24.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 
 command: geany

--- a/org.geany.Geany.yml
+++ b/org.geany.Geany.yml
@@ -1,6 +1,6 @@
 app-id: org.geany.Geany
 runtime: org.freedesktop.Sdk
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 
 command: geany

--- a/webkitgtk.yml
+++ b/webkitgtk.yml
@@ -18,11 +18,12 @@ config-opts:
   - -DENABLE_SPELLCHECK=OFF
   - -DENABLE_DOCUMENTATION=OFF
   - -DENABLE_MINIBROWSER=OFF
+  - -DUSE_SYSTEM_SYSPROF_CAPTURE=NO
   - -DENABLE_BUBBLEWRAP_SANDBOX=OFF  # Unused inside of flatpak
 sources:
   - type: archive
-    url: https://webkitgtk.org/releases/webkitgtk-2.44.3.tar.xz
-    sha256: dc82d042ecaca981a4852357c06e5235743319cf10a94cd36ad41b97883a0b54
+    url: https://webkitgtk.org/releases/webkitgtk-2.46.3.tar.xz
+    sha256: 85e09fa6ff9fea49678ba9975dbc64ea3242833f8f8a7d6a8937b2f292fcb28d
     x-checker-data:
       type: html
       url: https://webkitgtk.org/releases/
@@ -122,8 +123,8 @@ modules:
       - rm $FLATPAK_DEST/lib/*.a
     sources:
       - type: archive
-        url: https://github.com/libjxl/libjxl/archive/v0.10.3/libjxl-0.10.3.tar.gz
-        sha256: e0191411cfcd927eebe5392d030fe4283fe27ba1685ab7265104936e0b4283a6
+        url: https://github.com/libjxl/libjxl/archive/v0.11.0/libjxl-0.11.0.tar.gz
+        sha256: 7ce4ec8bb37a435a73ac18c4c9ff56c2dc6c98892bf3f53a328e3eca42efb9cf
         x-checker-data:
           type: json
           url: https://api.github.com/repos/libjxl/libjxl/releases/latest
@@ -154,8 +155,8 @@ modules:
       - --buildtype=plain
     sources:
       - type: archive
-        url: https://github.com/Igalia/WPEBackend-fdo/releases/download/1.14.2/wpebackend-fdo-1.14.2.tar.xz
-        sha256: 93c9766ae9864eeaeaee2b0a74f22cbca08df42c1a1bdb55b086f2528e380d38
+        url: https://github.com/Igalia/WPEBackend-fdo/releases/download/1.14.3/wpebackend-fdo-1.14.3.tar.xz
+        sha256: 10121842595a850291db3e82f3db0b9984df079022d386ce42c2b8508159dc6c
         x-checker-data:
           type: json
           url: https://api.github.com/repos/Igalia/WPEBackend-fdo/releases/latest

--- a/webkitgtk.yml
+++ b/webkitgtk.yml
@@ -85,11 +85,12 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DAVIF_CODEC_DAV1D=ON
+      - -DAVIF_LIBYUV=OFF
       - -DBUILD_SHARED_LIBS=ON
     sources:
       - type: archive
-        url: https://github.com/AOMediaCodec/libavif/archive/v1.0.4/libavif-1.0.4.tar.gz
-        sha256: dc56708c83a4b934a8af2b78f67f866ba2fb568605c7cf94312acf51ee57d146
+        url: https://github.com/AOMediaCodec/libavif/archive/v1.1.1/libavif-1.1.1.tar.gz
+        sha256: 914662e16245e062ed73f90112fbb4548241300843a7772d8d441bb6859de45b
         x-checker-data:
           type: json
           url: https://api.github.com/repos/AOMediaCodec/libavif/releases/latest


### PR DESCRIPTION
Update FDO to 24.08 and update all dependencies, supplying config fixes to allow them to build.

Replaces all active pull requests from flathubbot (117-125).