### PR TITLE
Add info for future maintainers and disable bot PRs for now.

### DIFF
--- a/FOR-MAINTANERS.md
+++ b/FOR-MAINTANERS.md
@@ -1,0 +1,31 @@
+# Information for future maintaners
+
+This is a document explaining why certain things in this repo are the way they are, for the benefit of whoever next inherits the maintenance of this package. This was first written by the maintainer from November 2021 to November 2024, [TiZ](https://github.com/TiZ-HugLife). Future maintainers and Flathub staff should feel free to update this file as they see fit.
+
+## Why FDO runtime?
+
+It's partially ideological, partially practical. Geany is a desktop-agnostic GTK3 application, and TiZ believed that desktop-agnostic applications fit best with the FDO runtime. It is a convention already followed with similar applications like Firefox.
+
+But there are practical benefits, too. Most of all, the desktop-specific runtimes go end-of-life twice as fast as FDO does. The current version of geany-plugins can't build on FDO 24.08 due to compiler errors on GCC 14. But FDO 23.08 won't go end-of-life until FDO 25.08 comes out. By then, hopefully there will be a release that addresses errors on newer compilers.
+
+## What's up with webkitgtk?
+
+Geany-plugins's dependency on webkitgtk would be a great reason to use the GNOME runtime despite Geany being desktop-agnostic, but GNOME doesn't ship the webkitgtk that Geany needs.
+
+All of the plugins that use libsoup use the older 2.x version, and GNOME's GTK3 webkit uses libsoup 3.x. You can't mix libsoup versions in one application, so we have to build webkit from scratch to use libsoup2. If Geany-plugins completes migration to libsoup3--something that is [slowly in progress](https://github.com/geany/geany-plugins/pull/1342)--using the GNOME runtime should definitely be revisited, because building webkitgtk is hands-down the *very worst* part of building this package locally.
+
+## What's the patch for?
+
+`native_dialogs.patch` adds file chooser portal support to Geany before it's officially available in the 2.1 release, because folks using Flatpak applications generally expect their platform-native file dialogs to appear. Geany's custom GTK3 file chooser allows changing the encoding of a file as you open it, which is a valid but niche use case.
+
+Geany's developers believe this case is more important than platform-native file dialogs, thus on Linux, this is disabled by default. So there's also a sed substitution in the manifest to enable it by default for this package.
+
+## Is there contention with the Geany developers?
+
+Kinda-sorta-not-really. TiZ was tired of a bunch of other stuff in the Linux app ecosystem, and this was just the straw that broke his back. There is less contention and hard feelings among the actual stakeholders than it seems from the fact that this is TiZ's last contribution to this package.
+
+Geany's developers are kinda-sorta at odds with Flathub because they have made a request that is impossible to accommodate, due to ideological differences between them and the stewards of Flathub. [The discussion is here,](https://github.com/flathub/org.geany.Geany/issues/92) but to summarize it, they want the Flathub page to display the maintainers of the package, but that's not what the developer field of the Flathub app page is supposed to do. It's supposed to show the people *actually developing* the software. However, the Flathub page doesn't meaningfully display the maintainers of a package, because they're sort of committed to a false dichotomy: maintained by the developers vs maintained by the community. This dichotomy and its implications are exacerbated by their terminology for it: verified vs unverified. This terminology stinks because it's not reflective of reality, or the way that distributions and other packaging formats operate. Unfortunately, [they are not interested in changing anything about it.](https://github.com/flathub-infra/website/issues/3131)
+
+Thus, it is impossible to satisfy either stakeholder in this conflict.
+
+This is the least relevant thing to actually maintaining the package, but anyone who does pick this up may have to deal with it, so I (TiZ) thought it at least worth mentioning and summarizing.

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+	"disable-external-data-checker": true
+}


### PR DESCRIPTION
This is my last contribution to this repo. After the bot finishes its redundant build and I get it merged, I will follow up with Flathub staff on next steps for retirement from maintenance on all the packages I had volunteered to take care of.

The reasoning I stated in #104 still holds true, so I'll repeat it here with an addendum: I'm tired of all of this. I'm tired of being caught between GNOME's overbearing plans for the ecosystem, and the people who distrust and/or resist Flatpak itself, which may partially be a means of resisting GNOME. I don't like what GNOME is doing, and I haven't for a very long time. But they hold all the cards, and all the control. It becomes harder every day to be civil to this group of people who ***absolutely do deserve civility***, because I am also incredibly angry that they are hellbent on using their dominance and control to eliminate everything about desktop Linux that made me passionate about it.

My time and energy is growing more and more limited all the time, and spending it on this is just... it's kind of soul-crushing now, to be honest. The Linux ecosystem will never again resemble what gave me passion for it. It's still better than Windows, but it's not something I really want to be part of anymore.

At the same time though, I know GNOME's aggressive homogenization of the ecosystem is in response to the trauma of various downstreams attempting to supply and support customizations that cause breakages to their applications and send angry users to their issue trackers, among other things. They are essentially acting to protect their own time and energy, just as I am. So despite growing angry for reasons that I feel are valid, and growing weary of that anger in and of itself, I also believe they don't deserve to have to deal with me as I am now.

Another factor in my retirement--the straw that broke my back, in fact--is the stalemate between [Geany developers' request to disambiguate developers and maintaners on the Flathub page](https://github.com/flathub/org.geany.Geany/issues/92), Flathub's inability to meaningfully do so, and [Flathub's failure to do anything about that.](https://github.com/flathub-infra/website/issues/3131)

This isn't the only package I have taken up the mantle of maintaining; two of the OBS plugins on Flathub are my responsibility, and I have let them absolutely languish because I am not using OBS Studio in my workflow anymore. I've also let Sonic 3 AIR languish despite having lofty plans to divorce it from Adwaita. Stepping away explicitly rather than just vanishing is the most responsible and considerate thing to do.